### PR TITLE
Pin ELB chart to 1.4.7

### DIFF
--- a/addons/aws-elb-controller/enable
+++ b/addons/aws-elb-controller/enable
@@ -44,7 +44,7 @@ echo "Enabling ELB controller"
 
 $HELM repo add eks https://aws.github.io/eks-charts
 $HELM repo update
-$HELM upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller --set image.repository=amazon/aws-alb-ingress-controller --set clusterName=$CLNAME -n kube-system
+$HELM upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller --version 1.4.7 --set clusterName=$CLNAME -n kube-system
 
 restart_service kubelet
 


### PR DESCRIPTION
Pinned ELB chart to 1.4.7 and removed docker repository since chart now uses the public ecr repository.
